### PR TITLE
Add `RMI-PACTA/developers` as `.md` `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,6 @@
 # @jdhoffa will be requested for review when someone opens 
 # a pull request.
 *       @jdhoffa
+# The entire tech team should be code-owners of all `*.md` 
+# files except for the README.md
+*.md !README.md @RMI-PACTA/developers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,5 @@
 *       @jdhoffa
 # The entire tech team should be code-owners of all `*.md` 
 # files except for the README.md
-*.md !README.md @RMI-PACTA/developers
+*.md @RMI-PACTA/developers
+README.md @jdhoffa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # @jdhoffa will be requested for review when someone opens 
 # a pull request.
 *       @jdhoffa
-# The entire tech team should be code-owners of all `*.md` 
-# files except for the README.md
+# The RMI-PATA developer team should be code-owners of all 
+# `*.md` files except for `README.md`.
 *.md @RMI-PACTA/developers
 README.md @jdhoffa


### PR DESCRIPTION
... except for `README.md`

This will:
* Automatically enforce consensus review on all `practices`
* Still allow me to make structural changes to the main page/ hugo website, other non-practice parts of this repository