### PR TITLE
migrate `CODEOWNERS` advice to "How" section

### DIFF
--- a/maintainer.md
+++ b/maintainer.md
@@ -24,6 +24,10 @@ Maintainers are the decision-makers for structural changes or contentious featur
 
 Maintainers should be particularly cautious about changes to repositories that are dependencies of larger workflows to avoid breaking changes.
 
+## Versioning and Release
+
+Maintainers are responsible for communicating overall application version through some informative version identifier. See [Software Versioning](version.md) for more information.
+
 ## Communication of Changes
 
 Any substantial change that may affect other parts of the workflow should be communicated, preferably in a tech review call or similar forum, to discuss the potential impacts and necessary adjustments.

--- a/maintainer.md
+++ b/maintainer.md
@@ -32,10 +32,10 @@ Maintainers are responsible for communicating overall application version throug
 
 Any substantial change that may affect other parts of the workflow should be communicated, preferably in a tech review call or similar forum, to discuss the potential impacts and necessary adjustments.
 
-## Practical Implications
-
-Maintainers of a repository will be defined using the `.github/CODEOWNERS` file of that repository. File-specific maintainers can also be defined in this manner. See [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) for more info. 
-
 ## References
 
 We considered aspects of the [ROpenSci Maintainer Definition](https://ropensci.org/blog/2023/02/07/what-does-it-mean-to-maintain-a-package/) when creating this document. 
+
+## How
+
+- The maintainer of a repository can be optionally communicated to the public by using GitHub's [`CODEOWNERS` feature](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).

--- a/version.md
+++ b/version.md
@@ -4,7 +4,7 @@ Versioning is a critical aspect of software development. It is the process of as
 
 ## Semantic Versioning
 
-Semantic versioning (SemVer) is a versioning scheme that provides a simple set of rules and requirements that dictate how version numbers are assigned and incremented. The version number is a three-part number in the format of `MAJOR.MINOR.PATCH`.
+Semantic versioning ([SemVer](https://semver.org/)) is a versioning scheme that provides a simple set of rules and requirements that dictate how version numbers are assigned and incremented. The version number is a three-part number in the format of `MAJOR.MINOR.PATCH`.
 - `MAJOR` version when you make incompatible API changes,
 - `MINOR` version when you add functionality in a backwards-compatible manner, and
 - `PATCH` version when you make backwards-compatible bug fixes, or maintenance/ upkeep and other developer-facing improvements.

--- a/version.md
+++ b/version.md
@@ -1,0 +1,34 @@
+# Software Versioning
+
+Versioning is a critical aspect of software development. It is the process of assigning identifiers to a package to distinguish it from other versions of the same package. In contrast to a "git hash", which serves as an immutable machine-friendly identifier of the state of the software, the version number serves more to communicate the function of the package to (human) users. This document outlines our practices for versioning a package.
+
+## Semantic Versioning
+
+Semantic versioning (SemVer) is a versioning scheme that provides a simple set of rules and requirements that dictate how version numbers are assigned and incremented. The version number is a three-part number in the format of `MAJOR.MINOR.PATCH`.
+- `MAJOR` version when you make incompatible API changes,
+- `MINOR` version when you add functionality in a backwards-compatible manner, and
+- `PATCH` version when you make backwards-compatible bug fixes, or maintenance/ upkeep and other developer-facing improvements.
+
+
+## Calender Versioning
+
+Calender versioning (CalVer) is a versioning scheme that uses some portion of the date of release as the version number. There are different styles of CalVer. One is very similar to SemVer, however the `MAJOR` version is instead replaced with the year of release, e.g. `YYYY.MINOR.PATH`. Other variants can be found here: [CalVer](https://calver.org/).
+
+## R Packages
+
+R packages should be versioned using a Semantic Versioning (SemVer) compliant variant as described in the [R package versioning guide](https://r-pkgs.org/release.html#release-version).
+
+This means, either standard SemVer, or the CalVer variant as described above. This may be the case, for example, in packages who's primary exported outputs are data, and the package is updated on a regular schedule.
+
+## Other Repositories
+
+At this stage, no clear guidance is given for other `RMI-PACTA` repositories. In general, some consistent tagging system may be useful (e.g. tag relevant images with `date-built`, or `COP CH 2024`, or other useful user-facing tags), but the specifics of this are left to the discretion of the repository maintainers.
+
+## References
+
+- [Semantic Versioning](https://semver.org/)
+- [Calender Versioning](https://calver.org/)
+
+## How
+
+-   [R package versioning guide](https://r-pkgs.org/release.html#release-version).

--- a/version.md
+++ b/version.md
@@ -1,6 +1,6 @@
 # Software Versioning
 
-Versioning is a critical aspect of software development. It is the process of assigning identifiers to a package to distinguish it from other versions of the same package. In contrast to a "git hash", which serves as an immutable machine-friendly identifier of the state of the software, the version number serves more to communicate the function of the package to (human) users. This document outlines our practices for versioning a package.
+Versioning is a critical aspect of software development. It is the process of assigning identifiers to a collection of code to distinguish it from other versions of the same collection. In contrast to a "git hash", which serves as an immutable machine-friendly identifier of the state of the code, the version number serves to communicate the behavior of the code to humans (and especially anticipated differences from earlier versions). This document outlines our practices for versioning code.
 
 ## Semantic Versioning
 

--- a/version.md
+++ b/version.md
@@ -12,7 +12,7 @@ Semantic versioning (SemVer) is a versioning scheme that provides a simple set o
 
 ## Calender Versioning
 
-Calender versioning (CalVer) is a versioning scheme that uses some portion of the date of release as the version number. There are different styles of CalVer. One is very similar to SemVer, however the `MAJOR` version is instead replaced with the year of release, e.g. `YYYY.MINOR.PATH`. Other variants can be found here: [CalVer](https://calver.org/).
+Calender versioning (CalVer) is a versioning scheme that uses some portion of the date of release as the version number. There are different styles of CalVer. One is very similar to SemVer, however the `MAJOR` version is instead replaced with the year of release, e.g. `YYYY.MINOR.PATCH`. Other variants can be found here: [CalVer](https://calver.org/).
 
 ## R Packages
 

--- a/version.md
+++ b/version.md
@@ -9,6 +9,7 @@ Semantic versioning (SemVer) is a versioning scheme that provides a simple set o
 - `MINOR` version when you add functionality in a backwards-compatible manner, and
 - `PATCH` version when you make backwards-compatible bug fixes, or maintenance/ upkeep and other developer-facing improvements.
 
+When a package is in a development stage (e.g. not yet ready for release), it is identified by "adding a large component" to the version number, e.g. `0.1.0.9000`. This is a signal to users that the package is in between stable releases.
 
 ## Calender Versioning
 

--- a/version.md
+++ b/version.md
@@ -5,9 +5,9 @@ Versioning is a critical aspect of software development. It is the process of as
 ## Semantic Versioning
 
 Semantic versioning ([SemVer](https://semver.org/)) is a versioning scheme that provides a simple set of rules and requirements that dictate how version numbers are assigned and incremented. The version number is a three-part number in the format of `MAJOR.MINOR.PATCH`.
-- `MAJOR` version when you make incompatible API changes,
-- `MINOR` version when you add functionality in a backwards-compatible manner, and
-- `PATCH` version when you make backwards-compatible bug fixes, or maintenance/ upkeep and other developer-facing improvements.
+- `MAJOR` version increments when you make backwards-incompatible changes
+- `MINOR` version increments when you add functionality in a backwards-compatible manner
+- `PATCH` version increments when you make backwards-compatible bug fixes, or maintenance, upkeep or any other developer-facing improvements
 
 When a package is in a development stage (e.g. not yet ready for release), it is identified by "adding a large component" to the version number, e.g. `0.1.0.9000`. This is a signal to users that the package is in between stable releases.
 


### PR DESCRIPTION
As the [README](https://github.com/RMI-PACTA/practices/blob/5f9fb7c31950ef658a5c51c5465ff935f1f33753/README.md?plain=1#L5) states, the goal of each `*.md` file in this repo should be to explain the "WHAT" and "WHY" of each practice, with only optional resources on the "HOW".

The original wording of the `maintainer.md` file was too prescriptive for using the `CODEOWNER` file.

As such, this PR moves the `CODEOWNER` implementation to a new "HOW" section. This is similar to how it is done for  [versions.md](https://github.com/RMI-PACTA/practices/blob/main/version.md#how)

Closes #35