### PR TITLE
move `CODEOWNERS` to HOW section

### DIFF
--- a/maintainer.md
+++ b/maintainer.md
@@ -32,10 +32,10 @@ Maintainers are responsible for communicating overall application version throug
 
 Any substantial change that may affect other parts of the workflow should be communicated, preferably in a tech review call or similar forum, to discuss the potential impacts and necessary adjustments.
 
-## Practical Implications
-
-Maintainers of a repository will be defined using the `.github/CODEOWNERS` file of that repository. File-specific maintainers can also be defined in this manner. See [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) for more info. 
-
 ## References
 
 We considered aspects of the [ROpenSci Maintainer Definition](https://ropensci.org/blog/2023/02/07/what-does-it-mean-to-maintain-a-package/) when creating this document. 
+
+## How
+
+- The maintainer of a repository can be optionally communicated to the public by using GitHub's [`CODEOWNERS` feature](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).


### PR DESCRIPTION
As the [README](https://github.com/RMI-PACTA/practices/blob/5f9fb7c31950ef658a5c51c5465ff935f1f33753/README.md?plain=1#L5) states, the goal of each `*.md` file in this repo should be to explain the "WHAT" and "WHY" of each practice, with only optional resources on the "HOW".

The original wording of the `maintainer.md` file was too prescriptive for using the `CODEOWNER` file.

As such, this PR moves the `CODEOWNER` implementation to a new "HOW" section. This is similar to how it is done for  [versions.md](https://github.com/RMI-PACTA/practices/blob/main/version.md#how)

Closes #35
Supersedes #36 